### PR TITLE
Fix unable to mapReduce with decorator on an Instance type

### DIFF
--- a/lib/MapReduce.ts
+++ b/lib/MapReduce.ts
@@ -35,7 +35,7 @@ export interface MapFunction<TDocument> {
  * @param {Value[]} values The values to reduce
  */
 export interface ReduceFunction<Key, Value> {
-    (key: Key, values: Value[]): Value
+    (key: Key, values: Value[]): Value | Value[] | any
 }
 
 /**

--- a/lib/Model.ts
+++ b/lib/Model.ts
@@ -730,17 +730,16 @@ export class Model<TDocument extends { _id?: any }, TInstance> {
             return new Bluebird<void>((resolve, reject) => {
                 if (options.out && options.out == "inline")
                     return reject(new Error("Expected a non-inline mapReduce output mode for this method signature"));
+                if (!instanceType.mapReduceOptions)
+                    return reject(new Error("mapReduceOptions not provided"));
                 let opts = <MongoDB.MapReduceOptions>options;
                 let out : {[op: string]: string} = {};
                 out[(<string>options.out)] = instanceType.collection;
                 opts.out = out;
-                if (instanceType.mapReduceOptions) {
-                    this.collection.mapReduce(instanceType.mapReduceOptions.map, instanceType.mapReduceOptions.reduce, opts, (err, data) => {
-                        if (err) return reject(err);
-                        return resolve();
-                    });
-                }
-                else return reject("mapReduceOptions not provided");
+                this.collection.mapReduce(instanceType.mapReduceOptions.map, instanceType.mapReduceOptions.reduce, opts, (err, data) => {
+                    if (err) return reject(err);
+                    return resolve();
+                });
             })
         }
     }

--- a/lib/Model.ts
+++ b/lib/Model.ts
@@ -271,7 +271,7 @@ export class Model<TDocument extends { _id?: any }, TInstance> {
         conditions = this._helpers.convertToDB(conditions);
 
         let cursor = this.collection.find(conditions);
-        
+
         if(fields)
             cursor = cursor.project(fields);
 
@@ -383,18 +383,18 @@ export class Model<TDocument extends { _id?: any }, TInstance> {
             if (cachedDocument) return cachedDocument;
             return new Bluebird<TDocument|null>((resolve, reject) => {
                 let cursor = this.collection.find(conditions);
-                    
+
                 if(options!.sort)
                     cursor = cursor.sort(options!.sort!);
-                
+
                 if(typeof options!.skip === "number")
                     cursor = cursor.skip(options!.skip!);
-                
+
                 cursor = cursor.limit(1);
-                    
+
                 if(options!.fields)
                     cursor = cursor.project(options!.fields!);
-                
+
                 return cursor.next((err, result) => {
                     if (err) return reject(err);
                     return resolve(result);
@@ -573,7 +573,7 @@ export class Model<TDocument extends { _id?: any }, TInstance> {
 
                 if (opts.multi)
                     return this.collection.updateMany(conditions, changes, opts, callback);
-                
+
                 return this.collection.updateOne(conditions, changes, opts, callback)
             })
         }).nodeify(callback);
@@ -671,7 +671,7 @@ export class Model<TDocument extends { _id?: any }, TInstance> {
                     if (err) return reject(err);
                     return resolve(response.result.n);
                 });
-                
+
                 this.collection.deleteMany(conditions, options!, (err, response) => {
                     if (err) return reject(err);
                     return resolve(response.result.n);
@@ -706,11 +706,12 @@ export class Model<TDocument extends { _id?: any }, TInstance> {
      * @param options Options used to configure how MongoDB runs the mapReduce operation on your collection.
      * @return A promise which completes when the mapReduce operation has written its results to the provided collection.
      */
-    mapReduce<Key, Value>(instanceType: InstanceImplementation<MapReducedDocument<Key, Value>, any> & { mapReduceOptions: MapReduceFunctions<TDocument, Key, Value> },
+    mapReduce<Key, Value>(instanceType: InstanceImplementation<MapReducedDocument<Key, Value>, any>,
         options: MapReduceOptions): Bluebird<void>;
-    mapReduce<Key, Value>(functions: (InstanceImplementation<MapReducedDocument<Key, Value>, any> & { mapReduceOptions: MapReduceFunctions<TDocument, Key, Value> }) |
+    mapReduce<Key, Value>(functions: InstanceImplementation<MapReducedDocument<Key, Value>, any> |
         MapReduceFunctions<TDocument, Key, Value>, options: MapReduceOptions) {
         type fn = MapReduceFunctions<TDocument, Key, Value>;
+        type instance = InstanceImplementation<MapReducedDocument<Key, Value>, any>
 
         if ((<fn>functions).map) {
             return new Bluebird<MapReducedDocument<Key, Value>[]>((resolve, reject) => {
@@ -725,7 +726,7 @@ export class Model<TDocument extends { _id?: any }, TInstance> {
             })
         }
         else {
-            let instanceType = <InstanceImplementation<MapReducedDocument<Key, Value>, any> & { mapReduceOptions: MapReduceFunctions<TDocument, Key, Value> }>functions;
+            let instanceType = <instance>functions;
             return new Bluebird<void>((resolve, reject) => {
                 if (options.out && options.out == "inline")
                     return reject(new Error("Expected a non-inline mapReduce output mode for this method signature"));
@@ -733,10 +734,13 @@ export class Model<TDocument extends { _id?: any }, TInstance> {
                 let out : {[op: string]: string} = {};
                 out[(<string>options.out)] = instanceType.collection;
                 opts.out = out;
-                this.collection.mapReduce(instanceType.mapReduceOptions.map, instanceType.mapReduceOptions.reduce, opts, (err, data) => {
-                    if (err) return reject(err);
-                    return resolve();
-                });
+                if (instanceType.mapReduceOptions) {
+                    this.collection.mapReduce(instanceType.mapReduceOptions.map, instanceType.mapReduceOptions.reduce, opts, (err, data) => {
+                        if (err) return reject(err);
+                        return resolve();
+                    });
+                }
+                else return reject("mapReduceOptions not provided");
             })
         }
     }

--- a/test/MapReduce.ts
+++ b/test/MapReduce.ts
@@ -44,6 +44,23 @@ class MapReducedInstance extends Iridium.Instance<Iridium.MapReducedDocument<str
     value: number;
 }
 
+@Iridium.MapReduce(function (this: TestDocument) {
+    emit(this.cust_id, this.amount);
+}, function (key: string, values: number[]) {
+    return values.reduce((sum, val) => sum + val, 0);
+})
+class DecoratedMapReducedInstance extends Iridium.Instance<Iridium.MapReducedDocument<string, number>, MapReducedInstance>{
+    static collection = "decoratedMapReduced";
+    _id: string;
+    value: number;
+}
+
+class NotMapReducedInstance extends Iridium.Instance<Iridium.MapReducedDocument<string, number>, MapReducedInstance>{
+    static collection = "notMapReduced";
+    _id: string;
+    value: number;
+}
+
 describe("Model", () => {
     let core = new Iridium.Core({ database: "test" });
 
@@ -59,6 +76,14 @@ describe("Model", () => {
                 { cust_id: "A123", amount: 300, status: "B" },
                 { cust_id: "B212", amount: 200, status: "A" }
             ]));
+        });
+
+        it("should correctly map and reduce with model and decorator", () => {
+            let reducedModel = new Iridium.Model<Iridium.MapReducedDocument<string, number>, DecoratedMapReducedInstance>(core, DecoratedMapReducedInstance);
+            let t = reducedModel.remove().then(() => model.mapReduce(DecoratedMapReducedInstance, {
+                out: "replace", query: { status: "A" }
+            }).then(() => reducedModel.find().toArray()));
+            return chai.expect(t).to.eventually.exist.and.have.length(2);
         });
 
         it("should correctly map and reduce with model", () => {
@@ -94,6 +119,13 @@ describe("Model", () => {
         it("should reject with wrong out option for model", () => {
             let t = model.mapReduce(MapReducedInstance, {
                 out: "inline", query: { status: "A" }
+            });
+            return chai.expect(t).to.eventually.be.rejected;
+        });
+
+        it("should reject with no mapReduce info in Instance type", () => {
+            let t = model.mapReduce(NotMapReducedInstance, {
+                out: "replace", query: { status: "A" }
             });
             return chai.expect(t).to.eventually.be.rejected;
         });


### PR DESCRIPTION
Sorry for knocking again.
I noticed that when applying mapReduce functions with decorators, it failed to compile. (Actually for the ugly static type checks I added at the last moment). So it seems better to me to check for those functions at runtime which will also be useful for JavaScript users. And added accompanying test.
Best regards.